### PR TITLE
add a Perlin noise generation in Python

### DIFF
--- a/demo/python/README.md
+++ b/demo/python/README.md
@@ -141,22 +141,34 @@ const NB_NS_IN_SEC = 1e9
 
 ### perlin noise
 ```nushell
-let noise = [
-    [amplitude, octaves];
-    [1.000,     3],
-    [0.500,     6],
-    [0.250,     12],
-    [0.125,     24],
-]
+const SEED = 123
+
+const NOISE = {
+    terrain: [
+        [amplitude, octaves];
+
+        [1.000,     1],
+        [0.500,     6],
+        [0.250,     12],
+    ],
+    forest: [
+        [amplitude, octaves];
+
+        [1.000,     1],
+        [0.500,     3],
+        [0.250,     12],
+    ]
+}
 
 python perlin.py ...[
-    -W 160
-    -H 90
-    -s 8
+    -W 40
+    -H 20
+    -s 32
     -t 100
     -f 60
-    --seed 123
+    --seed $SEED
     --show-fps
-    --noise ($noise | to json)
+    --terrain-noise ($NOISE.terrain | to json)
+    --biome-noise ($NOISE.forest | to json)
 ]
 ```

--- a/demo/python/README.md
+++ b/demo/python/README.md
@@ -160,6 +160,8 @@ const NOISE = {
     ]
 }
 
+const LAND_TYPES = { "ROCK": 0.1, "GRASS": 0.0, "WATER": "-inf" }
+
 python perlin.py ...[
     -W 40
     -H 20
@@ -170,5 +172,6 @@ python perlin.py ...[
     --show-fps
     --terrain-noise ($NOISE.terrain | to json)
     --biome-noise ($NOISE.forest | to json)
+    --land-types ($LAND_TYPES | to json)
 ]
 ```

--- a/demo/python/README.md
+++ b/demo/python/README.md
@@ -138,3 +138,25 @@ const NB_NS_IN_SEC = 1e9
     --fullscreen
 ]
 ```
+
+### perlin noise
+```nushell
+let noise = [
+    [amplitude, octaves];
+    [1.000,     3],
+    [0.500,     6],
+    [0.250,     12],
+    [0.125,     24],
+]
+
+python perlin.py ...[
+    -W 160
+    -H 90
+    -s 8
+    -t 100
+    -f 60
+    --seed 123
+    --show-fps
+    --noise ($noise | to json)
+]
+```

--- a/demo/python/perlin.py
+++ b/demo/python/perlin.py
@@ -11,11 +11,17 @@ from pathlib import Path
 from enum import Enum
 from random import choice
 from tqdm import trange
+import numpy as np
+from PIL import Image
 
 BLACK = (0, 0, 0)
 
 ANIMATION_SEQUENCE_LEN = 4
 ANIMATION_INV_SPEED = 5
+
+
+def info(msg: str):
+    print(f"[bold green]INFO[/bold green]: {msg}")
 
 
 class LandType(Enum):
@@ -525,17 +531,19 @@ def generate_cells(
     return cells
 
 
-def handle_events() -> (bool, bool):
+def handle_events() -> (bool, bool, bool):
     for event in pygame.event.get():
         if event.type == pygame.QUIT or (
             event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE
         ):
-            return False, None
+            return False, None, False
         elif event.type == pygame.KEYDOWN:
             if event.key == pygame.K_SPACE:
-                return True, True
+                return True, True, False
+            elif event.key == pygame.K_RETURN:
+                return True, False, True
 
-    return True, False
+    return True, False, False
 
 
 def show(
@@ -689,7 +697,12 @@ if __name__ == "__main__":
     t = 0
     running = True
     while running:
-        running, regenerate_cells = handle_events()
+        running, regenerate_cells, snapshot = handle_events()
+        if snapshot:
+            out = f"{time_ns()}.png"
+            image = np.transpose(pygame.surfarray.array3d(screen), (1, 0, 2))
+            Image.fromarray(image).save(out)
+            info(f"window saved in [purple]{out}[/purple]")
 
         if regenerate_cells:
             print()

--- a/demo/python/perlin.py
+++ b/demo/python/perlin.py
@@ -535,7 +535,12 @@ def handle_events() -> (bool, bool):
     return True, False
 
 
-def show(screen: pygame.surface.Surface, cells: List[Cell], s: int):
+def show(
+    screen: pygame.surface.Surface,
+    cells: List[Cell],
+    s: int,
+    show_grid: bool = False,
+):
     screen.fill(BLACK)
 
     for c in cells:
@@ -549,13 +554,16 @@ def show(screen: pygame.surface.Surface, cells: List[Cell], s: int):
                 (c.j * s, c.i * s),
             )
 
-    # draw a slightly transparent grid on top of the cells
-    for c in cells:
-        rect = (c.j * s, c.i * s, s, s)
-        color = BLACK + (64,)
-        shape_surf = pygame.Surface(pygame.Rect(rect).size, pygame.SRCALPHA)
-        pygame.draw.rect(shape_surf, color, shape_surf.get_rect(), width=1)
-        screen.blit(shape_surf, rect)
+    if show_grid:
+        # draw a slightly transparent grid on top of the cells
+        for c in cells:
+            rect = (c.j * s, c.i * s, s, s)
+            color = BLACK + (64,)
+            shape_surf = pygame.Surface(
+                pygame.Rect(rect).size, pygame.SRCALPHA
+            )
+            pygame.draw.rect(shape_surf, color, shape_surf.get_rect(), width=1)
+            screen.blit(shape_surf, rect)
 
     pygame.display.flip()
 
@@ -634,6 +642,7 @@ if __name__ == "__main__":
     parser.add_argument("--biome-noise", type=noise_as_json(), required=True)
     parser.add_argument("--forest-threshold", type=float, default=0.0)
     parser.add_argument("--land-types", type=land_types_as_json(), required=True)
+    parser.add_argument("--show-grid", action="store_true")
     args = parser.parse_args()
 
     pygame.init()
@@ -688,7 +697,7 @@ if __name__ == "__main__":
                 z=z,
             )
 
-        show(screen, cells, args.tile_size)
+        show(screen, cells, args.tile_size, show_grid=args.show_grid)
 
         dt = clock.tick(args.frame_rate) / 1000
         if args.show_fps:

--- a/demo/python/perlin.py
+++ b/demo/python/perlin.py
@@ -10,6 +10,7 @@ from tileset import load_tileset, Tile, Name
 from pathlib import Path
 from enum import Enum
 from random import choice
+from tqdm import trange
 
 BLACK = (0, 0, 0)
 
@@ -175,7 +176,7 @@ def generate_cells(
             sum(weight * n([i / h, j / w, z]) for weight, n in noise)
             for j in range(w + 1)
         ]
-        for i in range(h + 1)
+        for i in trange(h + 1)
     ]
 
     cells = []

--- a/demo/python/perlin.py
+++ b/demo/python/perlin.py
@@ -180,6 +180,7 @@ def generate_cells(
     ]
 
     cells = []
+    incomplete, bad_tile = False, None
     for i in range(h):
         for j in range(w):
             nw = to_land_type(noise_values[i][j])
@@ -193,9 +194,14 @@ def generate_cells(
             if fg is not None:
                 fg = tileset[fg]
 
+            if key not in TILEMAP:
+                incomplete, bad_tile = True, (nw, ne, sw, se)
+
             cells.append(Cell(i, j, background=bg, foreground=fg))
 
-    print(f"[bold green]INFO[/bold green]: done in {(time_ns() - t) / 1000} ms")
+    print(f"[bold green]INFO[/bold green]: done in {(time_ns() - t) / 1_000_000} ms")
+    if incomplete:
+        print(f"[bold yellow]WARNING[/bold yellow]: generation is incomplete with {bad_tile}")
 
     return cells
 

--- a/demo/python/perlin.py
+++ b/demo/python/perlin.py
@@ -14,13 +14,11 @@ from tqdm import trange
 
 BLACK = (0, 0, 0)
 
-# values need to be sorted from highest to lowest
-LAND_TYPES = {
-    "ROCK": 0.1,
-    "GRASS": 0.0,
-    "WATER": float("-inf"),
-}
-LandType = Enum("LandType", list(LAND_TYPES.keys()))
+
+class LandType(Enum):
+    ROCK = 'r'
+    GRASS = 'g'
+    WATER = 'w'
 
 
 @dataclass
@@ -31,21 +29,16 @@ class Cell:
     foreground: Tile | None
 
 
-def to_land_type(x: float) -> LandType:
-    for k, v in LAND_TYPES.items():
+def to_land_type(x: float, land_types) -> LandType:
+    for k, v in land_types.items():
         if x > v:
             return LandType._member_map_[k]
-
-
-def hash_lt(nw: LandType, ne: LandType, sw: LandType, se: LandType) -> int:
-    n = len(LAND_TYPES.keys())
-    return nw.value + n * ne.value + n ** 2 * sw.value + n ** 3 * se.value
 
 
 LT = LandType
 TILEMAP = {
     # iiii
-    hash_lt(LT.GRASS, LT.GRASS, LT.GRASS, LT.GRASS): [
+    "gggg": [
         ("grass_1", None),
         ("grass_2", None),
         ("grass_3", None),
@@ -56,107 +49,107 @@ TILEMAP = {
         ("grass_8", None),
         ("grass_9", None),
     ],
-    hash_lt(LT.WATER, LT.WATER, LT.WATER, LT.WATER): [("water", None)],
-    hash_lt(LT.ROCK, LT.ROCK, LT.ROCK, LT.ROCK): [("grass_1", None)],
+    "wwww": [("water", None)],
+    "rrrr": [("grass_1", None)],
 
     # iiij
-    hash_lt(LT.GRASS, LT.GRASS, LT.GRASS, LT.WATER): [("river_corner_north_west", None)],  # noqa: E501
-    hash_lt(LT.GRASS, LT.GRASS, LT.WATER, LT.GRASS): [("river_corner_north_east", None)],  # noqa: E501
-    hash_lt(LT.GRASS, LT.WATER, LT.GRASS, LT.GRASS): [("river_corner_south_west", None)],  # noqa: E501
-    hash_lt(LT.WATER, LT.GRASS, LT.GRASS, LT.GRASS): [("river_corner_south_east", None)],  # noqa: E501
+    "gggw": [("river_corner_north_west", None)],  # noqa: E501
+    "ggwg": [("river_corner_north_east", None)],  # noqa: E501
+    "gwgg": [("river_corner_south_west", None)],  # noqa: E501
+    "wggg": [("river_corner_south_east", None)],  # noqa: E501
 
-    hash_lt(LT.WATER, LT.WATER, LT.WATER, LT.GRASS): [("river_inv_corner_south_east", None)],  # noqa: E501
-    hash_lt(LT.WATER, LT.WATER, LT.GRASS, LT.WATER): [("river_inv_corner_south_west", None)],  # noqa: E501
-    hash_lt(LT.WATER, LT.GRASS, LT.WATER, LT.WATER): [("river_inv_corner_north_east", None)],  # noqa: E501
-    hash_lt(LT.GRASS, LT.WATER, LT.WATER, LT.WATER): [("river_inv_corner_north_west", None)],  # noqa: E501
+    "wwwg": [("river_inv_corner_south_east", None)],  # noqa: E501
+    "wwgw": [("river_inv_corner_south_west", None)],  # noqa: E501
+    "wgww": [("river_inv_corner_north_east", None)],  # noqa: E501
+    "gwww": [("river_inv_corner_north_west", None)],  # noqa: E501
 
-    hash_lt(LT.GRASS, LT.GRASS, LT.GRASS, LT.ROCK): [("rock_north_west", None)],  # noqa: E501
-    hash_lt(LT.GRASS, LT.GRASS, LT.ROCK, LT.GRASS): [("rock_north_east", None)],  # noqa: E501
-    hash_lt(LT.GRASS, LT.ROCK, LT.GRASS, LT.GRASS): [("rock_south_west", None)],  # noqa: E501
-    hash_lt(LT.ROCK, LT.GRASS, LT.GRASS, LT.GRASS): [("rock_south_east", None)],  # noqa: E501
+    "gggr": [("rock_north_west", None)],  # noqa: E501
+    "ggrg": [("rock_north_east", None)],  # noqa: E501
+    "grgg": [("rock_south_west", None)],  # noqa: E501
+    "rggg": [("rock_south_east", None)],  # noqa: E501
 
-    hash_lt(LT.WATER, LT.WATER, LT.WATER, LT.ROCK): [("water", "rock_north_west_2")],  # noqa: E501
-    hash_lt(LT.WATER, LT.WATER, LT.ROCK, LT.WATER): [("water", "rock_north_east_2")],  # noqa: E501
-    hash_lt(LT.WATER, LT.ROCK, LT.WATER, LT.WATER): [("water", "rock_south_west_2")],  # noqa: E501
-    hash_lt(LT.ROCK, LT.WATER, LT.WATER, LT.WATER): [("water", "rock_south_east_2")],  # noqa: E501
+    "wwwr": [("water", "rock_north_west_2")],  # noqa: E501
+    "wwrw": [("water", "rock_north_east_2")],  # noqa: E501
+    "wrww": [("water", "rock_south_west_2")],  # noqa: E501
+    "rwww": [("water", "rock_south_east_2")],  # noqa: E501
 
-    hash_lt(LT.ROCK, LT.ROCK, LT.ROCK, LT.WATER): [("water", "rock_corner_south_east_2")],  # noqa: E501
-    hash_lt(LT.ROCK, LT.ROCK, LT.WATER, LT.ROCK): [("water", "rock_corner_south_west_2")],  # noqa: E501
-    hash_lt(LT.ROCK, LT.WATER, LT.ROCK, LT.ROCK): [("water", "rock_corner_north_east_2")],  # noqa: E501
-    hash_lt(LT.WATER, LT.ROCK, LT.ROCK, LT.ROCK): [("water", "rock_corner_north_west_2")],  # noqa: E501
+    "rrrw": [("water", "rock_corner_south_east_2")],  # noqa: E501
+    "rrwr": [("water", "rock_corner_south_west_2")],  # noqa: E501
+    "rwrr": [("water", "rock_corner_north_east_2")],  # noqa: E501
+    "wrrr": [("water", "rock_corner_north_west_2")],  # noqa: E501
 
-    hash_lt(LT.ROCK, LT.ROCK, LT.ROCK, LT.GRASS): [("rock_corner_south_east", None)],  # noqa: E501
-    hash_lt(LT.ROCK, LT.ROCK, LT.GRASS, LT.ROCK): [("rock_corner_south_west", None)],  # noqa: E501
-    hash_lt(LT.ROCK, LT.GRASS, LT.ROCK, LT.ROCK): [("rock_corner_north_east", None)],  # noqa: E501
-    hash_lt(LT.GRASS, LT.ROCK, LT.ROCK, LT.ROCK): [("rock_corner_north_west", None)],  # noqa: E501
+    "rrrg": [("rock_corner_south_east", None)],  # noqa: E501
+    "rrgr": [("rock_corner_south_west", None)],  # noqa: E501
+    "rgrr": [("rock_corner_north_east", None)],  # noqa: E501
+    "grrr": [("rock_corner_north_west", None)],  # noqa: E501
 
     # iijj
-    hash_lt(LT.WATER, LT.GRASS, LT.GRASS, LT.WATER): [("river_diag_anti", None)],  # noqa: E501
-    hash_lt(LT.GRASS, LT.WATER, LT.WATER, LT.GRASS): [("river_diag", None)],
-    hash_lt(LT.GRASS, LT.GRASS, LT.WATER, LT.WATER): [("river_north", None)],
-    hash_lt(LT.GRASS, LT.WATER, LT.GRASS, LT.WATER): [("river_west", None)],
-    hash_lt(LT.WATER, LT.GRASS, LT.WATER, LT.GRASS): [("river_east", None)],
-    hash_lt(LT.WATER, LT.WATER, LT.GRASS, LT.GRASS): [("river_south", None)],
+    "wggw": [("river_diag_anti", None)],  # noqa: E501
+    "gwwg": [("river_diag", None)],
+    "ggww": [("river_north", None)],
+    "gwgw": [("river_west", None)],
+    "wgwg": [("river_east", None)],
+    "wwgg": [("river_south", None)],
 
-    hash_lt(LT.WATER, LT.ROCK, LT.ROCK, LT.WATER): [("water", "rock_diag_anti_2")],  # noqa: E501
-    hash_lt(LT.ROCK, LT.WATER, LT.WATER, LT.ROCK): [("water", "rock_diag_2")],
-    hash_lt(LT.ROCK, LT.ROCK, LT.WATER, LT.WATER): [("water", "rock_south_2")],
-    hash_lt(LT.ROCK, LT.WATER, LT.ROCK, LT.WATER): [("water", "rock_east_2")],
-    hash_lt(LT.WATER, LT.ROCK, LT.WATER, LT.ROCK): [("water", "rock_west_2")],
-    hash_lt(LT.WATER, LT.WATER, LT.ROCK, LT.ROCK): [("water", "rock_north_2")],
+    "wrrw": [("water", "rock_diag_anti_2")],  # noqa: E501
+    "rwwr": [("water", "rock_diag_2")],
+    "rrww": [("water", "rock_south_2")],
+    "rwrw": [("water", "rock_east_2")],
+    "wrwr": [("water", "rock_west_2")],
+    "wwrr": [("water", "rock_north_2")],
 
-    hash_lt(LT.ROCK, LT.GRASS, LT.GRASS, LT.ROCK): [("rock_diag", None)],
-    hash_lt(LT.GRASS, LT.ROCK, LT.ROCK, LT.GRASS): [("rock_diag_anti", None)],
-    hash_lt(LT.GRASS, LT.GRASS, LT.ROCK, LT.ROCK): [("rock_north", None)],
-    hash_lt(LT.GRASS, LT.ROCK, LT.GRASS, LT.ROCK): [("rock_west", None)],
-    hash_lt(LT.ROCK, LT.GRASS, LT.ROCK, LT.GRASS): [("rock_east", None)],
-    hash_lt(LT.ROCK, LT.ROCK, LT.GRASS, LT.GRASS): [("rock_south", None)],
+    "rggr": [("rock_diag", None)],
+    "grrg": [("rock_diag_anti", None)],
+    "ggrr": [("rock_north", None)],
+    "grgr": [("rock_west", None)],
+    "rgrg": [("rock_east", None)],
+    "rrgg": [("rock_south", None)],
 
     # iijk
-    hash_lt(LT.WATER, LT.WATER, LT.GRASS, LT.ROCK): [("river_south", "rock_north_west_2")],  # noqa: E501
-    hash_lt(LT.GRASS, LT.WATER, LT.ROCK, LT.WATER): [("river_west", "rock_north_east_2")],  # noqa: E501
-    hash_lt(LT.ROCK, LT.GRASS, LT.WATER, LT.WATER): [("river_north", "rock_south_east_2")],  # noqa: E501
-    hash_lt(LT.WATER, LT.ROCK, LT.WATER, LT.GRASS): [("river_east", "rock_south_west_2")],  # noqa: E501
+    "wwgr": [("river_south", "rock_north_west_2")],  # noqa: E501
+    "gwrw": [("river_west", "rock_north_east_2")],  # noqa: E501
+    "rgww": [("river_north", "rock_south_east_2")],  # noqa: E501
+    "wrwg": [("river_east", "rock_south_west_2")],  # noqa: E501
 
-    hash_lt(LT.WATER, LT.WATER, LT.ROCK, LT.GRASS): [("river_south", "rock_north_east_2")],  # noqa: E501
-    hash_lt(LT.ROCK, LT.WATER, LT.GRASS, LT.WATER): [("river_west", "rock_south_east_2")],  # noqa: E501
-    hash_lt(LT.GRASS, LT.ROCK, LT.WATER, LT.WATER): [("river_north", "rock_south_west_2")],  # noqa: E501
-    hash_lt(LT.WATER, LT.GRASS, LT.WATER, LT.ROCK): [("river_east", "rock_north_west_2")],  # noqa: E501
+    "wwrg": [("river_south", "rock_north_east_2")],  # noqa: E501
+    "rwgw": [("river_west", "rock_south_east_2")],  # noqa: E501
+    "grww": [("river_north", "rock_south_west_2")],  # noqa: E501
+    "wgwr": [("river_east", "rock_north_west_2")],  # noqa: E501
 
-    hash_lt(LT.ROCK, LT.ROCK, LT.WATER, LT.GRASS): [("river_east", "rock_south_2")],  # noqa: E501
-    hash_lt(LT.WATER, LT.ROCK, LT.GRASS, LT.ROCK): [("river_corner_south_east", "rock_west_2")],  # noqa: E501
-    hash_lt(LT.GRASS, LT.WATER, LT.ROCK, LT.ROCK): [("river_west", "rock_north_2")],  # noqa: E501
-    hash_lt(LT.ROCK, LT.GRASS, LT.ROCK, LT.WATER): [("river_corner_north_west", "rock_east_2")],  # noqa: E501
+    "rrwg": [("river_east", "rock_south_2")],  # noqa: E501
+    "wrgr": [("river_corner_south_east", "rock_west_2")],  # noqa: E501
+    "gwrr": [("river_west", "rock_north_2")],  # noqa: E501
+    "rgrw": [("river_corner_north_west", "rock_east_2")],  # noqa: E501
 
-    hash_lt(LT.ROCK, LT.ROCK, LT.GRASS, LT.WATER): [("river_corner_north_west", "rock_south_2")],  # noqa: E501
-    hash_lt(LT.GRASS, LT.ROCK, LT.WATER, LT.ROCK): [("river_corner_north_east", "rock_west_2")],  # noqa: E501
-    hash_lt(LT.WATER, LT.GRASS, LT.ROCK, LT.ROCK): [("river_east", "rock_north_2")],  # noqa: E501
-    hash_lt(LT.ROCK, LT.WATER, LT.ROCK, LT.GRASS): [("river_south", "rock_east_2")],  # noqa: E501
+    "rrgw": [("river_corner_north_west", "rock_south_2")],  # noqa: E501
+    "grwr": [("river_corner_north_east", "rock_west_2")],  # noqa: E501
+    "wgrr": [("river_east", "rock_north_2")],  # noqa: E501
+    "rwrg": [("river_south", "rock_east_2")],  # noqa: E501
 
-    hash_lt(LT.GRASS, LT.GRASS, LT.WATER, LT.ROCK): [("river_corner_north_east", "rock_north_west_2")],  # noqa: E501
-    hash_lt(LT.WATER, LT.GRASS, LT.ROCK, LT.GRASS): [("river_corner_south_east", "rock_north_east_2")],  # noqa: E501
-    hash_lt(LT.ROCK, LT.WATER, LT.GRASS, LT.GRASS): [("river_corner_south_west", "rock_south_east_2")],  # noqa: E501
-    hash_lt(LT.GRASS, LT.ROCK, LT.GRASS, LT.WATER): [("river_corner_north_west", "rock_south_west_2")],  # noqa: E501
+    "ggwr": [("river_corner_north_east", "rock_north_west_2")],  # noqa: E501
+    "wgrg": [("river_corner_south_east", "rock_north_east_2")],  # noqa: E501
+    "rwgg": [("river_corner_south_west", "rock_south_east_2")],  # noqa: E501
+    "grgw": [("river_corner_north_west", "rock_south_west_2")],  # noqa: E501
 
-    hash_lt(LT.GRASS, LT.GRASS, LT.ROCK, LT.WATER): [("river_corner_north_west", "rock_north_east_2")],  # noqa: E501
-    hash_lt(LT.ROCK, LT.GRASS, LT.WATER, LT.GRASS): [("river_corner_north_east", "rock_south_east_2")],  # noqa: E501
-    hash_lt(LT.WATER, LT.ROCK, LT.GRASS, LT.GRASS): [("river_corner_south_east", "rock_south_west_2")],  # noqa: E501
-    hash_lt(LT.GRASS, LT.WATER, LT.GRASS, LT.ROCK): [("river_corner_south_west", "rock_north_west_2")],  # noqa: E501
+    "ggrw": [("river_corner_north_west", "rock_north_east_2")],  # noqa: E501
+    "rgwg": [("river_corner_north_east", "rock_south_east_2")],  # noqa: E501
+    "wrgg": [("river_corner_south_east", "rock_south_west_2")],  # noqa: E501
+    "gwgr": [("river_corner_south_west", "rock_north_west_2")],  # noqa: E501
 
-    hash_lt(LT.GRASS, LT.WATER, LT.ROCK, LT.GRASS): [("river_corner_south_west", "rock_north_east_2")],  # noqa: E501
-    hash_lt(LT.ROCK, LT.GRASS, LT.GRASS, LT.WATER): [("river_corner_north_west", "rock_south_east_2")],  # noqa: E501
-    hash_lt(LT.GRASS, LT.ROCK, LT.WATER, LT.GRASS): [("river_corner_north_east", "rock_south_west_2")],  # noqa: E501
-    hash_lt(LT.WATER, LT.GRASS, LT.GRASS, LT.ROCK): [("river_corner_south_east", "rock_north_west_2")],  # noqa: E501
+    "gwrg": [("river_corner_south_west", "rock_north_east_2")],  # noqa: E501
+    "rggw": [("river_corner_north_west", "rock_south_east_2")],  # noqa: E501
+    "grwg": [("river_corner_north_east", "rock_south_west_2")],  # noqa: E501
+    "wggr": [("river_corner_south_east", "rock_north_west_2")],  # noqa: E501
 
-    hash_lt(LT.WATER, LT.GRASS, LT.ROCK, LT.WATER): [("river_inv_corner_north_east", "rock_north_east_2")],  # noqa: E501
-    hash_lt(LT.ROCK, LT.WATER, LT.WATER, LT.GRASS): [("river_inv_corner_south_east", "rock_south_east_2")],  # noqa: E501
-    hash_lt(LT.WATER, LT.ROCK, LT.GRASS, LT.WATER): [("river_inv_corner_south_west", "rock_south_west_2")],  # noqa: E501
-    hash_lt(LT.GRASS, LT.WATER, LT.WATER, LT.ROCK): [("river_inv_corner_north_west", "rock_north_west_2")],  # noqa: E501
+    "wgrw": [("river_inv_corner_north_east", "rock_north_east_2")],  # noqa: E501
+    "rwwg": [("river_inv_corner_south_east", "rock_south_east_2")],  # noqa: E501
+    "wrgw": [("river_inv_corner_south_west", "rock_south_west_2")],  # noqa: E501
+    "gwwr": [("river_inv_corner_north_west", "rock_north_west_2")],  # noqa: E501
 
-    hash_lt(LT.ROCK, LT.WATER, LT.GRASS, LT.ROCK): [("river_corner_south_west", "rock_diag_2")],  # noqa: E501
-    hash_lt(LT.GRASS, LT.ROCK, LT.ROCK, LT.WATER): [("river_corner_north_west", "rock_diag_anti_2")],  # noqa: E501
-    hash_lt(LT.ROCK, LT.GRASS, LT.WATER, LT.ROCK): [("river_corner_north_east", "rock_diag_2")],  # noqa: E501
-    hash_lt(LT.WATER, LT.ROCK, LT.ROCK, LT.GRASS): [("river_corner_south_east", "rock_diag_anti_2")],  # noqa: E501
+    "rwgr": [("river_corner_south_west", "rock_diag_2")],  # noqa: E501
+    "grrw": [("river_corner_north_west", "rock_diag_anti_2")],  # noqa: E501
+    "rgwr": [("river_corner_north_east", "rock_diag_2")],  # noqa: E501
+    "wrrg": [("river_corner_south_east", "rock_diag_anti_2")],  # noqa: E501
 }
 
 FOREST_TILEMAP = {
@@ -446,6 +439,7 @@ def generate_cells(
     terrain_noise,
     biome_noise,
     forest_threshold: float,
+    land_types,
     w: int,
     h: int,
     tileset: Dict[Name, Tile],
@@ -477,15 +471,17 @@ def generate_cells(
         for i in trange(h + 2)
     ]
 
+    tlt = lambda x: to_land_type(x, land_types=land_types)
+
     cells = []
     incomplete, bad_tile = False, None
     for i in range(1, h):
         for j in range(1, w):
-            nw = to_land_type(terrain_noise_values[i][j])
-            ne = to_land_type(terrain_noise_values[i][j + 1])
-            sw = to_land_type(terrain_noise_values[i + 1][j])
-            se = to_land_type(terrain_noise_values[i + 1][j + 1])
-            key = hash_lt(nw, ne, sw, se)
+            nw = tlt(terrain_noise_values[i][j])
+            ne = tlt(terrain_noise_values[i][j + 1])
+            sw = tlt(terrain_noise_values[i + 1][j])
+            se = tlt(terrain_noise_values[i + 1][j + 1])
+            key = ''.join([nw.value, ne.value, sw.value, se.value])
 
             bg, fg = choice(TILEMAP.get(key, [("spell_red", None)]))
 
@@ -493,11 +489,11 @@ def generate_cells(
             forest = [
                 (
                     biome_noise_values[a][b] > forest_threshold and
-                    to_land_type(terrain_noise_values[a][b]) ==
-                    to_land_type(terrain_noise_values[a][b + 1]) ==
-                    to_land_type(terrain_noise_values[a + 1][b]) ==
-                    to_land_type(terrain_noise_values[a + 1][b + 1]) and
-                    to_land_type(terrain_noise_values[a][b]) in valid
+                    tlt(terrain_noise_values[a][b]) ==
+                    tlt(terrain_noise_values[a][b + 1]) ==
+                    tlt(terrain_noise_values[a + 1][b]) ==
+                    tlt(terrain_noise_values[a + 1][b + 1]) and
+                    tlt(terrain_noise_values[a][b]) in valid
                 )
                 for a, b in [
                     (i - 1, j - 1), (i - 1, j), (i - 1, j + 1),
@@ -597,6 +593,26 @@ def noise_as_json():
     return type_func
 
 
+def land_types_as_json():
+    def type_func(val: str) -> dict:
+        try:
+            lt = json.loads(val)
+        except Exception:
+            raise Exception("value given to --land-types is not valid JSON")
+
+        if not isinstance(lt, dict):
+            raise Exception(f"should be a dict, found {type(lt).__name__}")
+
+        expected = ["ROCK", "GRASS", "WATER"]
+        if sorted(lt.keys()) != sorted(expected):
+            raise Exception(
+                f"bad keys, expected {expected}, found {list(lt.keys())}"
+            )
+
+        return {k: float(v) for k, v in lt.items()}
+    return type_func
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--map-width", "-W", type=int, required=True)
@@ -609,6 +625,7 @@ if __name__ == "__main__":
     parser.add_argument("--terrain-noise", type=noise_as_json(), required=True)
     parser.add_argument("--biome-noise", type=noise_as_json(), required=True)
     parser.add_argument("--forest-threshold", type=float, default=0.0)
+    parser.add_argument("--land-types", type=land_types_as_json(), required=True)
     args = parser.parse_args()
 
     pygame.init()
@@ -635,6 +652,7 @@ if __name__ == "__main__":
         terrain_noise,
         biome_noise,
         args.forest_threshold,
+        args.land_types,
         args.map_width,
         args.map_height,
         tiles,
@@ -655,6 +673,7 @@ if __name__ == "__main__":
                 terrain_noise,
                 biome_noise,
                 args.forest_threshold,
+                args.land_types,
                 args.map_width,
                 args.map_height,
                 tiles,

--- a/demo/python/perlin.py
+++ b/demo/python/perlin.py
@@ -452,12 +452,12 @@ def generate_cells(
     terrain_noise_values = [
         [
             sum(
-                weight * n([i / (h + 1), j / (w + 1), z])
+                weight * n([i / (h + 2), j / (w + 2), z])
                 for weight, n in terrain_noise
             )
-            for j in range(w + 2)
+            for j in range(w + 3)
         ]
-        for i in trange(h + 2)
+        for i in trange(h + 3)
     ]
 
     biome_noise_values = [
@@ -475,8 +475,8 @@ def generate_cells(
 
     cells = []
     incomplete, bad_tile = False, None
-    for i in range(1, h):
-        for j in range(1, w):
+    for i in range(1, h + 1):
+        for j in range(1, w + 1):
             nw = tlt(terrain_noise_values[i][j])
             ne = tlt(terrain_noise_values[i][j + 1])
             sw = tlt(terrain_noise_values[i + 1][j])
@@ -510,7 +510,7 @@ def generate_cells(
                 incomplete, bad_tile = True, (nw, ne, sw, se)
 
             cells.append(Cell(
-                i, j,
+                i - 1, j - 1,
                 background=tileset[bg],
                 foreground=tileset.get(fg),
             ))

--- a/demo/python/perlin.py
+++ b/demo/python/perlin.py
@@ -444,6 +444,7 @@ FOREST_TILEMAP = {
 
 def generate_cells(
     noise,
+    noise_on_top,
     w: int,
     h: int,
     tileset: Dict[Name, Tile],
@@ -464,10 +465,6 @@ def generate_cells(
         for i in trange(h + 2)
     ]
 
-    noise_on_top = [
-        (1.0, PerlinNoise(octaves=1, seed=123)),
-        (0.5, PerlinNoise(octaves=3, seed=123)),
-    ]
     noise_on_top_values = [
         [
             sum(
@@ -608,7 +605,8 @@ if __name__ == "__main__":
     parser.add_argument("--change-with-time", "-t", type=float)
     parser.add_argument("--show-fps", action="store_true")
     parser.add_argument("--seed", type=int)
-    parser.add_argument("--noise", type=noise_as_json())
+    parser.add_argument("--noise", type=noise_as_json(), required=True)
+    parser.add_argument("--noise-on-top", type=noise_as_json(), required=True)
     args = parser.parse_args()
 
     pygame.init()
@@ -626,8 +624,12 @@ if __name__ == "__main__":
         (n["amplitude"], PerlinNoise(octaves=n["octaves"], seed=args.seed))
         for n in args.noise
     ]
+    noise_on_top = [
+        (n["amplitude"], PerlinNoise(octaves=n["octaves"], seed=args.seed))
+        for n in args.noise_on_top
+    ]
 
-    cells = generate_cells(noise, args.map_width, args.map_height, tiles)
+    cells = generate_cells(noise, noise_on_top, args.map_width, args.map_height, tiles)
 
     t = 0
     running = True
@@ -637,7 +639,7 @@ if __name__ == "__main__":
         if regenerate_cells:
             print()
             z = t / args.change_with_time if args.change_with_time is not None else 0.0
-            cells = generate_cells(noise, args.map_width, args.map_height, tiles, z=z)
+            cells = generate_cells(noise, noise_on_top, args.map_width, args.map_height, tiles, z=z)
 
         show(screen, cells, args.tile_size)
 

--- a/demo/python/perlin.py
+++ b/demo/python/perlin.py
@@ -445,6 +445,7 @@ FOREST_TILEMAP = {
 def generate_cells(
     terrain_noise,
     biome_noise,
+    forest_threshold: float,
     w: int,
     h: int,
     tileset: Dict[Name, Tile],
@@ -491,7 +492,7 @@ def generate_cells(
             valid = [LT.GRASS, LT.ROCK]
             forest = [
                 (
-                    biome_noise_values[a][b] > 0.0 and
+                    biome_noise_values[a][b] > forest_threshold and
                     to_land_type(terrain_noise_values[a][b]) ==
                     to_land_type(terrain_noise_values[a][b + 1]) ==
                     to_land_type(terrain_noise_values[a + 1][b]) ==
@@ -607,6 +608,7 @@ if __name__ == "__main__":
     parser.add_argument("--seed", type=int)
     parser.add_argument("--terrain-noise", type=noise_as_json(), required=True)
     parser.add_argument("--biome-noise", type=noise_as_json(), required=True)
+    parser.add_argument("--forest-threshold", type=float, default=0.0)
     args = parser.parse_args()
 
     pygame.init()
@@ -630,7 +632,12 @@ if __name__ == "__main__":
     ]
 
     cells = generate_cells(
-        terrain_noise, biome_noise, args.map_width, args.map_height, tiles
+        terrain_noise,
+        biome_noise,
+        args.forest_threshold,
+        args.map_width,
+        args.map_height,
+        tiles,
     )
 
     t = 0
@@ -645,9 +652,13 @@ if __name__ == "__main__":
             else:
                 z = 0.0
             cells = generate_cells(
-                terrain_noise, biome_noise,
-                args.map_width, args.map_height,
-                tiles, z=z
+                terrain_noise,
+                biome_noise,
+                args.forest_threshold,
+                args.map_width,
+                args.map_height,
+                tiles,
+                z=z,
             )
 
         show(screen, cells, args.tile_size)

--- a/demo/python/perlin.py
+++ b/demo/python/perlin.py
@@ -549,6 +549,14 @@ def show(screen: pygame.surface.Surface, cells: List[Cell], s: int):
                 (c.j * s, c.i * s),
             )
 
+    # draw a slightly transparent grid on top of the cells
+    for c in cells:
+        rect = (c.j * s, c.i * s, s, s)
+        color = BLACK + (64,)
+        shape_surf = pygame.Surface(pygame.Rect(rect).size, pygame.SRCALPHA)
+        pygame.draw.rect(shape_surf, color, shape_surf.get_rect(), width=1)
+        screen.blit(shape_surf, rect)
+
     pygame.display.flip()
 
 

--- a/demo/python/perlin.py
+++ b/demo/python/perlin.py
@@ -159,6 +159,288 @@ TILEMAP = {
     hash_lt(LT.WATER, LT.ROCK, LT.ROCK, LT.GRASS): [("river_corner_south_east", "rock_diag_anti_2")],  # noqa: E501
 }
 
+FOREST_TILEMAP = {
+    # full forest
+    "111111111": ["forest"],
+
+    # exactly 4 in the corners
+    "000011011": ["forest_corner_north_west", "forest_corner_in_north_west"],
+    "000110110": ["forest_corner_north_east", "forest_corner_in_north_east"],
+    "011011000": ["forest_corner_south_west", "forest_corner_in_south_west"],
+    "110110000": ["forest_corner_south_east", "forest_corner_in_south_east"],
+
+    "000110111": ["forest_corner_north_east", "forest_corner_in_north_east"],
+    "000111110": ["forest_corner_north_east", "forest_corner_in_north_east"],
+    "001110110": ["forest_corner_north_east", "forest_corner_in_north_east"],
+    "001110111": ["forest_corner_north_east", "forest_corner_in_north_east"],
+    "001111110": ["forest_corner_north_east", "forest_corner_in_north_east"],
+    "010110110": ["forest_corner_north_east", "forest_corner_in_north_east"],
+    "010110111": ["forest_corner_north_east", "forest_corner_in_north_east"],
+    "010111110": ["forest_corner_north_east", "forest_corner_in_north_east"],
+    "011110110": ["forest_corner_north_east", "forest_corner_in_north_east"],
+    "011110111": ["forest_corner_north_east", "forest_corner_in_north_east"],
+    "100110110": ["forest_corner_north_east", "forest_corner_in_north_east"],
+    "100110111": ["forest_corner_north_east", "forest_corner_in_north_east"],
+    "100111110": ["forest_corner_north_east", "forest_corner_in_north_east"],
+    "101110110": ["forest_corner_north_east", "forest_corner_in_north_east"],
+    "101110111": ["forest_corner_north_east", "forest_corner_in_north_east"],
+    "101111110": ["forest_corner_north_east", "forest_corner_in_north_east"],
+
+    "011011001": ["forest_corner_south_west", "forest_corner_in_south_west"],
+    "011011010": ["forest_corner_south_west", "forest_corner_in_south_west"],
+    "011011100": ["forest_corner_south_west", "forest_corner_in_south_west"],
+    "011011101": ["forest_corner_south_west", "forest_corner_in_south_west"],
+    "011011110": ["forest_corner_south_west", "forest_corner_in_south_west"],
+    "011111000": ["forest_corner_south_west", "forest_corner_in_south_west"],
+    "011111001": ["forest_corner_south_west", "forest_corner_in_south_west"],
+    "011111010": ["forest_corner_south_west", "forest_corner_in_south_west"],
+    "011111100": ["forest_corner_south_west", "forest_corner_in_south_west"],
+    "011111101": ["forest_corner_south_west", "forest_corner_in_south_west"],
+    "111011000": ["forest_corner_south_west", "forest_corner_in_south_west"],
+    "111011001": ["forest_corner_south_west", "forest_corner_in_south_west"],
+    "111011010": ["forest_corner_south_west", "forest_corner_in_south_west"],
+    "111011100": ["forest_corner_south_west", "forest_corner_in_south_west"],
+    "111011101": ["forest_corner_south_west", "forest_corner_in_south_west"],
+    "111011110": ["forest_corner_south_west", "forest_corner_in_south_west"],
+
+    "110110001": ["forest_corner_south_east", "forest_corner_in_south_east"],
+    "110110010": ["forest_corner_south_east", "forest_corner_in_south_east"],
+    "110110011": ["forest_corner_south_east", "forest_corner_in_south_east"],
+    "110110100": ["forest_corner_south_east", "forest_corner_in_south_east"],
+    "110110101": ["forest_corner_south_east", "forest_corner_in_south_east"],
+    "110111000": ["forest_corner_south_east", "forest_corner_in_south_east"],
+    "110111001": ["forest_corner_south_east", "forest_corner_in_south_east"],
+    "110111010": ["forest_corner_south_east", "forest_corner_in_south_east"],
+    "110111100": ["forest_corner_south_east", "forest_corner_in_south_east"],
+    "110111101": ["forest_corner_south_east", "forest_corner_in_south_east"],
+    "111110000": ["forest_corner_south_east", "forest_corner_in_south_east"],
+    "111110001": ["forest_corner_south_east", "forest_corner_in_south_east"],
+    "111110010": ["forest_corner_south_east", "forest_corner_in_south_east"],
+    "111110011": ["forest_corner_south_east", "forest_corner_in_south_east"],
+    "111110100": ["forest_corner_south_east", "forest_corner_in_south_east"],
+    "111110101": ["forest_corner_south_east", "forest_corner_in_south_east"],
+
+    "000011111": ["forest_corner_north_west", "forest_corner_in_north_west"],
+    "000111011": ["forest_corner_north_west", "forest_corner_in_north_west"],
+    "001011011": ["forest_corner_north_west", "forest_corner_in_north_west"],
+    "001011111": ["forest_corner_north_west", "forest_corner_in_north_west"],
+    "001111011": ["forest_corner_north_west", "forest_corner_in_north_west"],
+    "010011011": ["forest_corner_north_west", "forest_corner_in_north_west"],
+    "010011111": ["forest_corner_north_west", "forest_corner_in_north_west"],
+    "010111011": ["forest_corner_north_west", "forest_corner_in_north_west"],
+    "100011011": ["forest_corner_north_west", "forest_corner_in_north_west"],
+    "100011111": ["forest_corner_north_west", "forest_corner_in_north_west"],
+    "100111011": ["forest_corner_north_west", "forest_corner_in_north_west"],
+    "101011011": ["forest_corner_north_west", "forest_corner_in_north_west"],
+    "101011111": ["forest_corner_north_west", "forest_corner_in_north_west"],
+    "101111011": ["forest_corner_north_west", "forest_corner_in_north_west"],
+    "110011011": ["forest_corner_north_west", "forest_corner_in_north_west"],
+    "110011111": ["forest_corner_north_west", "forest_corner_in_north_west"],
+
+    # exact cardinal directions
+    "000111111": ["forest_north"],
+    "111111000": ["forest_south"],
+    "110110110": ["forest_east"],
+    "011011011": ["forest_west"],
+
+    "001111111": ["forest_north"],
+    "010111111": ["forest_north"],
+    "101111111": ["forest_north"],
+    "100111111": ["forest_north"],
+
+    "111111001": ["forest_south"],
+    "111111010": ["forest_south"],
+    "111111101": ["forest_south"],
+    "111111100": ["forest_south"],
+
+    "110110111": ["forest_east"],
+    "110111110": ["forest_east"],
+    "111110110": ["forest_east"],
+    "111110111": ["forest_east"],
+
+    "011011111": ["forest_west"],
+    "011111011": ["forest_west"],
+    "111011011": ["forest_west"],
+    "111011111": ["forest_west"],
+
+    "011111111": ["forest_corner_inv_north_west"],
+    "110111111": ["forest_corner_inv_north_east"],
+    "111111110": ["forest_corner_inv_south_east"],
+    "111111011": ["forest_corner_inv_south_west"],
+
+    "110111011": ["forest_diag"],
+    "011111110": ["forest_diag_anti"],
+
+    # 3 or less
+    "000010000": ["tree_1", "tree_2", "tree_3"],
+    "000010001": ["tree_1", "tree_2", "tree_3"],
+    "000010010": ["tree_1", "tree_2", "tree_3"],
+    "000010011": ["tree_1", "tree_2", "tree_3"],
+    "000010100": ["tree_1", "tree_2", "tree_3"],
+    "000010101": ["tree_1", "tree_2", "tree_3"],
+    "000010110": ["tree_1", "tree_2", "tree_3"],
+    "000011000": ["tree_1", "tree_2", "tree_3"],
+    "000011001": ["tree_1", "tree_2", "tree_3"],
+    "000011010": ["tree_1", "tree_2", "tree_3"],
+    "000011100": ["tree_1", "tree_2", "tree_3"],
+    "000110000": ["tree_1", "tree_2", "tree_3"],
+    "000110001": ["tree_1", "tree_2", "tree_3"],
+    "000110010": ["tree_1", "tree_2", "tree_3"],
+    "000110100": ["tree_1", "tree_2", "tree_3"],
+    "000111000": ["tree_1", "tree_2", "tree_3"],
+    "001010000": ["tree_1", "tree_2", "tree_3"],
+    "001010001": ["tree_1", "tree_2", "tree_3"],
+    "001010010": ["tree_1", "tree_2", "tree_3"],
+    "001010100": ["tree_1", "tree_2", "tree_3"],
+    "001011000": ["tree_1", "tree_2", "tree_3"],
+    "001110000": ["tree_1", "tree_2", "tree_3"],
+    "010010000": ["tree_1", "tree_2", "tree_3"],
+    "010010001": ["tree_1", "tree_2", "tree_3"],
+    "010010010": ["tree_1", "tree_2", "tree_3"],
+    "010010100": ["tree_1", "tree_2", "tree_3"],
+    "010011000": ["tree_1", "tree_2", "tree_3"],
+    "010110000": ["tree_1", "tree_2", "tree_3"],
+    "011010000": ["tree_1", "tree_2", "tree_3"],
+    "100010000": ["tree_1", "tree_2", "tree_3"],
+    "100010001": ["tree_1", "tree_2", "tree_3"],
+    "100010010": ["tree_1", "tree_2", "tree_3"],
+    "100010100": ["tree_1", "tree_2", "tree_3"],
+    "100011000": ["tree_1", "tree_2", "tree_3"],
+    "100110000": ["tree_1", "tree_2", "tree_3"],
+    "101010000": ["tree_1", "tree_2", "tree_3"],
+    "110010000": ["tree_1", "tree_2", "tree_3"],
+
+    # exactly 4 without the corners
+    "000010111": ["tree_1", "tree_2", "tree_3"],
+    "000011101": ["tree_1", "tree_2", "tree_3"],
+    "000011110": ["tree_1", "tree_2", "tree_3"],
+    "000110011": ["tree_1", "tree_2", "tree_3"],
+    "000110101": ["tree_1", "tree_2", "tree_3"],
+    "000111001": ["tree_1", "tree_2", "tree_3"],
+    "000111010": ["tree_1", "tree_2", "tree_3"],
+    "000111100": ["tree_1", "tree_2", "tree_3"],
+    "001010011": ["tree_1", "tree_2", "tree_3"],
+    "001010101": ["tree_1", "tree_2", "tree_3"],
+    "001010110": ["tree_1", "tree_2", "tree_3"],
+    "001011001": ["tree_1", "tree_2", "tree_3"],
+    "001011010": ["tree_1", "tree_2", "tree_3"],
+    "001011100": ["tree_1", "tree_2", "tree_3"],
+    "001110001": ["tree_1", "tree_2", "tree_3"],
+    "001110010": ["tree_1", "tree_2", "tree_3"],
+    "001110100": ["tree_1", "tree_2", "tree_3"],
+    "001111000": ["tree_1", "tree_2", "tree_3"],
+    "010010011": ["tree_1", "tree_2", "tree_3"],
+    "010010101": ["tree_1", "tree_2", "tree_3"],
+    "010010110": ["tree_1", "tree_2", "tree_3"],
+    "010011001": ["tree_1", "tree_2", "tree_3"],
+    "010011010": ["tree_1", "tree_2", "tree_3"],
+    "010011100": ["tree_1", "tree_2", "tree_3"],
+    "010110001": ["tree_1", "tree_2", "tree_3"],
+    "010110010": ["tree_1", "tree_2", "tree_3"],
+    "010110100": ["tree_1", "tree_2", "tree_3"],
+    "010111000": ["tree_1", "tree_2", "tree_3"],
+    "011010001": ["tree_1", "tree_2", "tree_3"],
+    "011010010": ["tree_1", "tree_2", "tree_3"],
+    "011010100": ["tree_1", "tree_2", "tree_3"],
+    "011110000": ["tree_1", "tree_2", "tree_3"],
+    "100010011": ["tree_1", "tree_2", "tree_3"],
+    "100010101": ["tree_1", "tree_2", "tree_3"],
+    "100010110": ["tree_1", "tree_2", "tree_3"],
+    "100011001": ["tree_1", "tree_2", "tree_3"],
+    "100011010": ["tree_1", "tree_2", "tree_3"],
+    "100011100": ["tree_1", "tree_2", "tree_3"],
+    "100110001": ["tree_1", "tree_2", "tree_3"],
+    "100110010": ["tree_1", "tree_2", "tree_3"],
+    "100110100": ["tree_1", "tree_2", "tree_3"],
+    "100111000": ["tree_1", "tree_2", "tree_3"],
+    "101010001": ["tree_1", "tree_2", "tree_3"],
+    "101010010": ["tree_1", "tree_2", "tree_3"],
+    "101010100": ["tree_1", "tree_2", "tree_3"],
+    "101011000": ["tree_1", "tree_2", "tree_3"],
+    "101110000": ["tree_1", "tree_2", "tree_3"],
+    "110010001": ["tree_1", "tree_2", "tree_3"],
+    "110010010": ["tree_1", "tree_2", "tree_3"],
+    "110010100": ["tree_1", "tree_2", "tree_3"],
+    "110011000": ["tree_1", "tree_2", "tree_3"],
+    "111010000": ["tree_1", "tree_2", "tree_3"],
+
+    # exactly 5 without the ones grouped together
+    "000111101": ["tree_1", "tree_2", "tree_3"],
+    "001010111": ["tree_1", "tree_2", "tree_3"],
+    "001011101": ["tree_1", "tree_2", "tree_3"],
+    "001011110": ["tree_1", "tree_2", "tree_3"],
+    "001110011": ["tree_1", "tree_2", "tree_3"],
+    "001110101": ["tree_1", "tree_2", "tree_3"],
+    "001111001": ["tree_1", "tree_2", "tree_3"],
+    "001111010": ["tree_1", "tree_2", "tree_3"],
+    "001111100": ["tree_1", "tree_2", "tree_3"],
+    "010010111": ["tree_1", "tree_2", "tree_3"],
+    "010011101": ["tree_1", "tree_2", "tree_3"],
+    "010011110": ["tree_1", "tree_2", "tree_3"],
+    "010110011": ["tree_1", "tree_2", "tree_3"],
+    "010110101": ["tree_1", "tree_2", "tree_3"],
+    "010111001": ["tree_1", "tree_2", "tree_3"],
+    "010111010": ["tree_1", "tree_2", "tree_3"],
+    "010111100": ["tree_1", "tree_2", "tree_3"],
+    "011010011": ["tree_1", "tree_2", "tree_3"],
+    "011010101": ["tree_1", "tree_2", "tree_3"],
+    "011010110": ["tree_1", "tree_2", "tree_3"],
+    "011110001": ["tree_1", "tree_2", "tree_3"],
+    "011110010": ["tree_1", "tree_2", "tree_3"],
+    "011110100": ["tree_1", "tree_2", "tree_3"],
+    "100010111": ["tree_1", "tree_2", "tree_3"],
+    "100011101": ["tree_1", "tree_2", "tree_3"],
+    "100011110": ["tree_1", "tree_2", "tree_3"],
+    "100110011": ["tree_1", "tree_2", "tree_3"],
+    "100110101": ["tree_1", "tree_2", "tree_3"],
+    "100111001": ["tree_1", "tree_2", "tree_3"],
+    "100111010": ["tree_1", "tree_2", "tree_3"],
+    "100111100": ["tree_1", "tree_2", "tree_3"],
+    "101010011": ["tree_1", "tree_2", "tree_3"],
+    "101010101": ["tree_1", "tree_2", "tree_3"],
+    "101010110": ["tree_1", "tree_2", "tree_3"],
+    "101011001": ["tree_1", "tree_2", "tree_3"],
+    "101011010": ["tree_1", "tree_2", "tree_3"],
+    "101011100": ["tree_1", "tree_2", "tree_3"],
+    "101110001": ["tree_1", "tree_2", "tree_3"],
+    "101110010": ["tree_1", "tree_2", "tree_3"],
+    "101110100": ["tree_1", "tree_2", "tree_3"],
+    "101111000": ["tree_1", "tree_2", "tree_3"],
+    "110010011": ["tree_1", "tree_2", "tree_3"],
+    "110010101": ["tree_1", "tree_2", "tree_3"],
+    "110010110": ["tree_1", "tree_2", "tree_3"],
+    "110011001": ["tree_1", "tree_2", "tree_3"],
+    "110011010": ["tree_1", "tree_2", "tree_3"],
+    "110011100": ["tree_1", "tree_2", "tree_3"],
+    "111010001": ["tree_1", "tree_2", "tree_3"],
+    "111010010": ["tree_1", "tree_2", "tree_3"],
+    "111010100": ["tree_1", "tree_2", "tree_3"],
+
+    # 6 or more
+    "001111101": ["tree_1", "tree_2", "tree_3"],
+    "010111101": ["tree_1", "tree_2", "tree_3"],
+    "011010111": ["tree_1", "tree_2", "tree_3"],
+    "011110011": ["tree_1", "tree_2", "tree_3"],
+    "011110101": ["tree_1", "tree_2", "tree_3"],
+    "100111101": ["tree_1", "tree_2", "tree_3"],
+    "101010111": ["tree_1", "tree_2", "tree_3"],
+    "101011101": ["tree_1", "tree_2", "tree_3"],
+    "101011110": ["tree_1", "tree_2", "tree_3"],
+    "101110011": ["tree_1", "tree_2", "tree_3"],
+    "101110101": ["tree_1", "tree_2", "tree_3"],
+    "101111001": ["tree_1", "tree_2", "tree_3"],
+    "101111010": ["tree_1", "tree_2", "tree_3"],
+    "101111100": ["tree_1", "tree_2", "tree_3"],
+    "101111101": ["tree_1", "tree_2", "tree_3"],
+    "110010111": ["tree_1", "tree_2", "tree_3"],
+    "110011101": ["tree_1", "tree_2", "tree_3"],
+    "110011110": ["tree_1", "tree_2", "tree_3"],
+    "111010011": ["tree_1", "tree_2", "tree_3"],
+    "111010101": ["tree_1", "tree_2", "tree_3"],
+    "111010110": ["tree_1", "tree_2", "tree_3"],
+    "111010111": ["tree_1", "tree_2", "tree_3"],
+}
+
 
 def generate_cells(
     noise,
@@ -173,16 +455,34 @@ def generate_cells(
 
     noise_values = [
         [
-            sum(weight * n([i / h, j / w, z]) for weight, n in noise)
-            for j in range(w + 1)
+            sum(
+                weight * n([i / (h + 1), j / (w + 1), z])
+                for weight, n in noise
+            )
+            for j in range(w + 2)
         ]
-        for i in trange(h + 1)
+        for i in trange(h + 2)
+    ]
+
+    noise_on_top = [
+        (1.0, PerlinNoise(octaves=1, seed=123)),
+        (0.5, PerlinNoise(octaves=3, seed=123)),
+    ]
+    noise_on_top_values = [
+        [
+            sum(
+                weight * n([i / (h + 1), j / (w + 1), z])
+                for weight, n in noise_on_top
+            )
+            for j in range(w + 2)
+        ]
+        for i in trange(h + 2)
     ]
 
     cells = []
     incomplete, bad_tile = False, None
-    for i in range(h):
-        for j in range(w):
+    for i in range(1, h):
+        for j in range(1, w):
             nw = to_land_type(noise_values[i][j])
             ne = to_land_type(noise_values[i][j + 1])
             sw = to_land_type(noise_values[i + 1][j])
@@ -190,14 +490,36 @@ def generate_cells(
             key = hash_lt(nw, ne, sw, se)
 
             bg, fg = choice(TILEMAP.get(key, [("spell_red", None)]))
-            bg = tileset[bg]
-            if fg is not None:
-                fg = tileset[fg]
+
+            valid = [LT.GRASS, LT.ROCK]
+            forest = [
+                (
+                    noise_on_top_values[a][b] > 0.0 and
+                    to_land_type(noise_values[a][b]) ==
+                    to_land_type(noise_values[a][b + 1]) ==
+                    to_land_type(noise_values[a + 1][b]) ==
+                    to_land_type(noise_values[a + 1][b + 1]) and
+                    to_land_type(noise_values[a][b]) in valid
+                )
+                for a, b in [
+                    (i - 1, j - 1), (i - 1, j), (i - 1, j + 1),
+                    (i, j - 1),     (i, j),     (i, j + 1),
+                    (i + 1, j - 1), (i + 1, j), (i + 1, j + 1),
+                ]
+            ]
+
+            if forest[4]:
+                fkey = ''.join(map(str, map(int, forest)))
+                fg = choice(FOREST_TILEMAP.get(fkey, ["spell_red"]))
 
             if key not in TILEMAP:
                 incomplete, bad_tile = True, (nw, ne, sw, se)
 
-            cells.append(Cell(i, j, background=bg, foreground=fg))
+            cells.append(Cell(
+                i, j,
+                background=tileset[bg],
+                foreground=tileset.get(fg),
+            ))
 
     print(f"[bold green]INFO[/bold green]: done in {(time_ns() - t) / 1_000_000} ms")
     if incomplete:

--- a/demo/python/perlin.py
+++ b/demo/python/perlin.py
@@ -1,0 +1,201 @@
+from perlin_noise import PerlinNoise
+from typing import List, Any, Dict
+import pygame
+import argparse
+from dataclasses import dataclass
+from rich import print
+from time import time_ns
+import json
+from tileset import load_tileset, Tile, Name
+from pathlib import Path
+from enum import Enum
+
+BLACK = (0, 0, 0)
+
+LandType = Enum("LandType", ["ROCK", "GRASS", "BEACH", "WATER"])
+
+
+@dataclass
+class Cell:
+    i: int
+    j: int
+    background: Tile
+    foreground: Tile | None
+
+
+def to_land_type(x: float) -> LandType:
+    if x > 0.1:
+        return LandType.ROCK
+    elif x > 0.0:
+        return LandType.GRASS
+    elif x > -0.1:
+        return LandType.BEACH
+    else:
+        return LandType.WATER
+
+
+def generate_cells(
+    noise,
+    w: int,
+    h: int,
+    tileset: Dict[Name, Tile],
+    z: float = 0.0,
+) -> List[Cell]:
+    t = time_ns()
+
+    print("[bold green]INFO[/bold green]: starting generating cells")
+
+    noise_values = [
+        [
+            sum(weight * n([i / h, j / w, z]) for weight, n in noise)
+            for j in range(w + 1)
+        ]
+        for i in range(h + 1)
+    ]
+
+    cells = []
+    for i in range(h):
+        for j in range(w):
+            nw = to_land_type(noise_values[i][j])
+            ne = to_land_type(noise_values[i][j + 1])
+            sw = to_land_type(noise_values[i + 1][j])
+            se = to_land_type(noise_values[i + 1][j + 1])
+
+            if nw == ne == sw == se == LandType.GRASS:
+                bg = tileset["grass_1"]
+            elif nw == ne == sw == se == LandType.ROCK:
+                bg = tileset["grass_1"]
+            elif nw == ne == sw == se == LandType.BEACH:
+                bg = tileset["sand_path"]
+            elif nw == ne == sw == se == LandType.WATER:
+                bg = tileset["water"]
+            else:
+                bg = tileset["spell_red"]
+            fg = None
+            cells.append(Cell(i, j, background=bg, foreground=fg))
+
+    print(f"[bold green]INFO[/bold green]: done in {(time_ns() - t) / 1000} ms")
+
+    return cells
+
+
+def handle_events() -> (bool, bool):
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT or (
+            event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE
+        ):
+            return False, None
+        elif event.type == pygame.KEYDOWN:
+            if event.key == pygame.K_SPACE:
+                return True, True
+
+    return True, False
+
+
+def show(screen: pygame.surface.Surface, cells: List[Cell], s: int):
+    screen.fill(BLACK)
+
+    for c in cells:
+        screen.blit(
+            pygame.transform.scale(c.background.image, (s, s)),
+            (c.j * s, c.i * s),
+        )
+        if c.foreground is not None:
+            screen.blit(
+                pygame.transform.scale(c.foreground.image, (s, s)),
+                (c.j * s, c.i * s),
+            )
+
+    pygame.display.flip()
+
+
+def is_number(obj: Any):
+    return isinstance(obj, float) or isinstance(obj, int)
+
+
+def noise_as_json():
+    def type_func(val: str) -> dict:
+        try:
+            noise = json.loads(val)
+        except Exception:
+            raise Exception("value given to --noise is not valid JSON")
+
+        if not isinstance(noise, list):
+            raise Exception("not a list")
+        if len(noise) == 0:
+            raise Exception("empty list")
+
+        for i, x in enumerate(noise):
+            if not isinstance(x, dict):
+                raise Exception(
+                    f"$.{i} should be a dict, found {type(x).__name__}"
+                )
+
+            expected = ["amplitude", "octaves"]
+            if sorted(x.keys()) != expected:
+                raise Exception(
+                    f"$.{i} has bad keys, expected {expected}, found {list(x.keys())}"
+                )
+            if not is_number(x["amplitude"]):
+                t = type(x['amplitude']).__name__
+                raise Exception(
+                    f"$.{i}.amplitude should be a number, found {t}"
+                )
+            if not is_number(x["octaves"]):
+                t = type(x['octaves']).__name__
+                raise Exception(
+                    f"$.{i}.octaves should be a number, found {t}"
+                )
+        return noise
+    return type_func
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--map-width", "-W", type=int, required=True)
+    parser.add_argument("--map-height", "-H", type=int, required=True)
+    parser.add_argument("--tile-size", "-s", type=int, required=True)
+    parser.add_argument("--frame-rate", "-f", type=int, default=30)
+    parser.add_argument("--change-with-time", "-t", type=float)
+    parser.add_argument("--show-fps", action="store_true")
+    parser.add_argument("--seed", type=int)
+    parser.add_argument("--noise", type=noise_as_json())
+    args = parser.parse_args()
+
+    pygame.init()
+    pygame.font.init()
+    screen = pygame.display.set_mode((
+        args.map_width * args.tile_size,
+        args.map_height * args.tile_size,
+    ))
+    clock = pygame.time.Clock()
+    dt = 0
+
+    tiles, _, _ = load_tileset(Path("../../punyworld.json"))
+
+    noise = [
+        (n["amplitude"], PerlinNoise(octaves=n["octaves"], seed=args.seed))
+        for n in args.noise
+    ]
+
+    cells = generate_cells(noise, args.map_width, args.map_height, tiles)
+
+    t = 0
+    running = True
+    while running:
+        running, regenerate_cells = handle_events()
+
+        if regenerate_cells:
+            print()
+            z = t / args.change_with_time if args.change_with_time is not None else 0.0
+            cells = generate_cells(noise, args.map_width, args.map_height, tiles, z=z)
+
+        show(screen, cells, args.tile_size)
+
+        dt = clock.tick(args.frame_rate) / 1000
+        if args.show_fps:
+            print(clock.get_fps(), end='\r')
+
+        t += 1
+
+    pygame.quit()

--- a/demo/python/requirements.txt
+++ b/demo/python/requirements.txt
@@ -7,3 +7,4 @@ pillow==10.4.0
 matplotlib==3.9.1
 rich==13.7.1
 PyQt5==5.15.10
+perlin_noise==1.12


### PR DESCRIPTION
greatly inspired by [_Procedural world generation with Perlin Noise_](https://youtu.be/eiM_AStmeGE)

`demo/python/perlin.py` will generate maps with
- three levels: water, grass and _rocky_ terrain
- with or without trees

## some examples
![1721383294562930444](https://github.com/user-attachments/assets/83753583-2ad1-43bd-9baa-9a335424473d)
![1721383298441458523](https://github.com/user-attachments/assets/31d70d48-6f01-4de3-965f-9fe246b3d326)
![1721383305655638542](https://github.com/user-attachments/assets/b93de347-e18e-4d3b-84b9-f65d26021c49)
> **Note**
>
> zoomed out and less noise

![1721383343283886894](https://github.com/user-attachments/assets/ad8180dc-88a3-4c0f-b762-5bdfa54a09ba)
